### PR TITLE
Simplify run_landclim(), assume `landclim` is available on the PATH

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -2,7 +2,7 @@
 
 *we currently don't have a guide on setting up the environment on Windows machines*
 
-# Ubuntu 16.04 LTS (Xenial Xerus)
+# Ubuntu
 
 ## Setting up the development environment
 
@@ -15,8 +15,13 @@ First install the required software:
 * Geospatial Data Abstraction Library `libgdal` ≥ 1.6.3 (required by the R-package `rgdal`)
 
 All of those are in the main Ubuntu repositories, so they can simply be installed by executing the following command in the command line:
+For Ubuntu 16.04 (Xenial Xerus):
 ```bash
 $ sudo apt install git texlive r-base libxml2-dev libproj-dev libgdal-dev
+```
+For Ubuntu 17.10 (Artful Aardvark):
+```bash
+$ sudo apt install git texlive r-base libxml2-dev libproj-dev libgdal-dev libudunits2-dev
 ```
 
 ---

--- a/R/simulate.R
+++ b/R/simulate.R
@@ -1,46 +1,24 @@
-
-lc_path=NULL # assign lc_path a value. Needed to avoid that `R CMD check` complains about "no visible binding for global variable ‘lc_path’"
-
-set_landclim_path <- function(landclim_path){
-  if(file.exists(landclim_path)) {
-    assign("lc_path", landclim_path, envir=globalenv())
-  } else {
-    print("Invalid path to LandClim executable.")
-    }
-}
-
-simulate <- function(control_file){
-  print("This is an old function. Use run_landclim() instead.")
-  ### Todo: Prototype!
-  oldwd <- getwd()
-  setwd(paste(getwd(), "/Input/", sep=""))
-  if(file.exists(control_file)) {
-    system(paste(lc_path, control_file, sep=" "))
-
-  } else {
-    print("Invalid path to LandClim control file.")
-  }
-  setwd(oldwd)
-}
-
 run_landclim <- function(control_file = "control.xml") {
-  print("Works only for Ubuntu until now!")
-  print("Working directory must be at the site level.")
-  
-  if (file.exists(paste0("Input/", control_file, sep = "")) & file.exists(lc_path)) {
+  cat("Works only for Ubuntu until now!\n")
+  cat("Working directory must be at the site level.\n")
+  lc_path <- Sys.which("landclim")["landclim"]
+  input_dir <- paste(getwd(), "Input", sep="/")
+  output_dir <- paste(getwd(), "Output", sep="/")
+  control_file <- paste(input_dir, "control.xml", sep="/")
+  cat(paste0("Landclim executable: ", lc_path, "\nInput directory: ", input_dir, "\nOutput directory: ", output_dir, "\n"))
+
+  if (!file.exists(lc_path)) {
+    cat(paste0("Could not find the LandClim executable! Make sure you can start LandClim in any working directory only by typing 'landclim' (see manual for details).\n"))
+  } else if (!file.exists(control_file)) {
+    cat(paste0("The control file does not exist! It must be located at the following path: ", control_file, "\n"))
+  } else {
     oldwd <- getwd()
-    dir.create("Output")
+    dir.create(output_dir, showWarnings = FALSE)
     file.remove(list.files("Output", full=TRUE))
-    setwd(paste(oldwd, "/Input/", sep = ""))
-    system(paste0(lc_path, " ", control_file))
+    setwd(input_dir)
+    system2(lc_path, control_file)
     setwd(oldwd)
     clean_output_ubuntu()
-  } else {
-    print("Invalid path to LandClim executable or to control file.")
-    print(paste0("Landclim path: ", lc_path))
-    print(paste0("Control file: ", paste(getwd(), "/Input/", control_file, sep = "")))
-    print(paste0("Names of *INPUT* and *OUTPUT* folders in the control file unfortunately must be Input and Output:"))
-    print(list.files())
   }
 }
 
@@ -48,7 +26,6 @@ run_landclim <- function(control_file = "control.xml") {
 
 clean_output_ubuntu <- function(){
   fis <- list.files()
-  file.copy(fis[grep("Output", fis)], paste("Output/",fis[grep("Output", fis)], sep=""))
-  file.remove(fis[grep(c("csv"), fis)])
-  file.remove(fis[grep(c("txt"), fis)])
+  file.copy(fis[grep("Output", fis)], paste("Output/",fis[grep("Output", fis)], sep="")) # Why is the `Output` directory copied into itself?
+  file.remove(fis[grep(c("\\.(csv|txt)$"), fis)])
 }

--- a/man/run_landclim.Rd
+++ b/man/run_landclim.Rd
@@ -19,8 +19,13 @@ run_landclim(control_file)
 \details{
 The working directory needs to be set to the level above "Input" and "Output" folders of LandClim, thus at the "site" level. Until now, the folder names are hard-coded, thus need to be "Input" and "Output", not e.g. input! Feel free to fix this!
 
-You need to set the path to your LandClim executable before you run LandClim using this function.
+It is assumed that LandClim is installed in a way, that the command `landclim` is available in the command line (regardless of the current working directory).
 
+If that is not the case, you can do the following in Ubuntu:
+Add the following line to the end of the file \code{.bashrc} in your home directory: \code{PATH="$PATH:/path/to/landclim"} (replace \code{/path/to/landclim} with the real path of the directory in which LandClim can be found).
+Then run the following command in the command line: \code{source ~/.bashrc}
+
+Now you should be able to simply enter \code{landclim} in the command line to start LandClim. And calling \code{run_landclim()} in R should also work.
 }
 
 \references{
@@ -29,12 +34,3 @@ You need to set the path to your LandClim executable before you run LandClim usi
 \author{
 Klara Dolos
 }
-
-\seealso{
-set_landclim_path
-}
-\examples{
-
-}
-
-


### PR DESCRIPTION
When this pull request is applied, `run_landclim()` should be able to pick up the location of the LandClim executable. The LandClim executable is assumed to be available on the PATH, meaning it can be accessed from any working directory just by typing `landclim`.

If that's not the case, e.g. on Ubuntu you can add the following line to the end of the file `.bashrc` in your home directory:
```bash
PATH="$PATH:/path/to/landclim"
```
(replace `/path/to/landclim` with the path to the directory, in which the executable is located)
After a reboot of the computer, `run_landclim()` will automatically pick up the location of the LandClim executable.

This is intended as a (partial) fix for #10 (only tested on Ubuntu).

By the way: You might want to follow these instructions to https://github.com/KIT-IfGG/LandClimTools/files/712147/travis.pdf . That would enable the badge in the README (![Build status](https://img.shields.io/travis/KIT-IfGG/LandClimTools/master.svg?style=flat-square)), which can display if the current commit builds cleanly or if it has problems.